### PR TITLE
Fix near format money and add vercel to whitelist

### DIFF
--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -29,6 +29,7 @@ async function init() {
     'http://localhost:8080',
     'https://baf-wallet.netlify.app',
     'https://baf-wallet-v2-git-deploy-work-baf-wallet.vercel.app',
+    'https://baf-wallet-v2.vercel.app'
   ];
   const corsOptions = {
     origin: function (origin, callback) {

--- a/libs/base-components/src/InputNumeric.svelte
+++ b/libs/base-components/src/InputNumeric.svelte
@@ -7,7 +7,7 @@
 
 <label class="">
   <span class="">{label}</span>
-  <input type="number" class="" {placeholder} bind:value {required} />
+  <input type="number" step="any" class="" {placeholder} bind:value {required} />
 </label>
 
 <style>

--- a/libs/near/src/web/SendFormPart.svelte
+++ b/libs/near/src/web/SendFormPart.svelte
@@ -1,12 +1,23 @@
 <script lang="ts">
-  import { Chain, GenericTxSupportedActions, CreateTxReturn, ed25519, PublicKey } from '@baf-wallet/interfaces';
-  import { NearBuildTxParams, WrappedNearChainInterface } from '@baf-wallet/near';
+  import {
+    Chain,
+    GenericTxSupportedActions,
+    CreateTxReturn,
+    ed25519,
+    PublicKey,
+  } from '@baf-wallet/interfaces';
+  import {
+    NearBuildTxParams,
+    WrappedNearChainInterface,
+  } from '@baf-wallet/near';
 
   import Input from '@baf-wallet/base-components/Input.svelte';
   import InputNumeric from '@baf-wallet/base-components/InputNumeric.svelte';
-  let recipientAccountID: string, amount: number;
-  export let chainInterface: WrappedNearChainInterface
-  export let edPK: PublicKey<ed25519>
+  import { utils } from 'near-api-js';
+  import BN from 'bn.js';
+  let recipientAccountID: string, amountNear: number;
+  export let chainInterface: WrappedNearChainInterface;
+  export let edPK: PublicKey<ed25519>;
 
   export const createTX = async (): Promise<
     CreateTxReturn<NearBuildTxParams>
@@ -14,16 +25,16 @@
     if (!chainInterface || !edPK) {
       throw new Error('You must have an initialized account with NEAR');
     }
+    const amountYoctoNearBN = utils.format.NEAR_NOMINATION.muln(amountNear)
     const txParams: NearBuildTxParams = {
       actions: [
         {
           type: GenericTxSupportedActions.TRANSFER,
-          amount: amount.toString(),
+          amount: amountYoctoNearBN.toString(10),
         },
       ],
       senderPk: edPK,
-      senderAccountID: chainInterface.getInner().nearMasterAccount
-        .accountId,
+      senderAccountID: chainInterface.getInner().nearMasterAccount.accountId,
       recipientAccountID,
     };
     return { txParams, recipientUser: recipientAccountID };
@@ -39,6 +50,6 @@
 <InputNumeric
   label="Sending to"
   placeholder="0 Near"
-  bind:value={amount}
+  bind:value={amountNear}
   required={true}
 />


### PR DESCRIPTION
- Change from Yocto Near to Near in the send money form part
- Add vercel to cors whitelist